### PR TITLE
Ported multiple changes made on internal version

### DIFF
--- a/MarkdownRendererPlugin/README.md
+++ b/MarkdownRendererPlugin/README.md
@@ -10,7 +10,7 @@ This list can be reached and amended through the following steps:
 2. In the screen select "Markdown Renderer" tab
 3. There you should see the following screen:
 ![initialAdminScreen](src/main/resources/images/initialAdminScreen.png)<br/>
-Checking "Allow Plain URL" enables usage of Plain URL source for user, refer to section [Plain URL Parameters](#1) for more information.<br/>
+Checking "Allow Plain URL" enables usage of Plain URL source for users, refer to section [Plain URL Parameters](#1) for more information.<br/>
 "Sources List" presents the table of sources that plugin shall propose to users. From there you can view, add and delete sources.
 <br/> Each source has the following parameters:
    * Name -> name of the source, must be unique
@@ -59,7 +59,33 @@ Supported Wiki extensions:
 * Table of Contents
 * Code block
 
+#### Example of rendering images through base64 code
+
+> README.md:
+>
+> ```
+> ![base64Image](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABK0AAAS7C....)
+> ```
+
+#### Example of rendering images by relative path
+
+> File structure:
+>
+>```
+> root folder
+> ├── README.md
+> └── pictures
+>     └── image.png
+>```
+>
+> README.md:
+>
+>```
+> ![relativePathImage](pictures/image.png)
+>```
+
 ## Revision history
-| Version | Date       | Author          | Confluence version | Description      |
-|---------|------------|-----------------|--------------------|------------------|
-| 01.00   | 12.04.2024 | Gautier Devuyst | 8.5.4              | Initial version. |
+| Version | Date       | Author          | Confluence version | Description                                                                                                                                                            |
+|---------|------------|-----------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 01.01   | 07.11.2024 | Gautier Devuyst | 8.5.4              | Moved logic to check non-nullness of parameters only in relevant Source Type + updated flexmark library version + leading ">" are now properly removed in quoted code. |
+| 01.00   | 12.04.2024 | Gautier Devuyst | 8.5.4              | Initial version.                                                                                                                                                       |

--- a/MarkdownRendererPlugin/pom.xml
+++ b/MarkdownRendererPlugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.octopusden.octopus.cdt.mdrenderer</groupId>
     <artifactId>markdown-renderer-plugin</artifactId>
-    <version>01.00</version>
+    <version>01.01</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Markdown Renderer Plugin for Confluence</name>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-all</artifactId>
-            <version>0.35.10</version>
+            <version>0.64.8</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/MarkdownRendererPlugin/src/main/java/org/octopusden/octopus/cdt/mdrenderer/renderingengine/MarkdownRenderer.java
+++ b/MarkdownRendererPlugin/src/main/java/org/octopusden/octopus/cdt/mdrenderer/renderingengine/MarkdownRenderer.java
@@ -4,7 +4,7 @@ import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.ext.toc.TocExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.util.options.MutableDataSet;
+import com.vladsch.flexmark.util.data.MutableDataSet;
 
 import java.util.Arrays;
 

--- a/MarkdownRendererPlugin/src/main/resources/MarkdownRendererPlugin.properties
+++ b/MarkdownRendererPlugin/src/main/resources/MarkdownRendererPlugin.properties
@@ -1,6 +1,6 @@
 MarkdownRendererPlugin.mdrenderer-macro.label=Markdown Renderer Plugin
-MarkdownRendererPlugin.mdrenderer-macro.param.sourceUrl.label=Source URL
-MarkdownRendererPlugin.mdrenderer-macro.param.sourceUrl.desc=Source URL of the repository, linked to Version Control System (Git, SVN, ...)
+MarkdownRendererPlugin.mdrenderer-macro.param.sourceName.label=Source Name
+MarkdownRendererPlugin.mdrenderer-macro.param.sourceName.desc=Source Name of the repository, linked to Version Control System (Git, SVN, ...)
 MarkdownRendererPlugin.mdrenderer-macro.param.svnCountry.label=Client Country
 MarkdownRendererPlugin.mdrenderer-macro.param.svnCountry.desc=Client Country name
 MarkdownRendererPlugin.mdrenderer-macro.param.svnBranchPath.label=Branch Path

--- a/MarkdownRendererPlugin/src/main/resources/atlassian-plugin.xml
+++ b/MarkdownRendererPlugin/src/main/resources/atlassian-plugin.xml
@@ -39,7 +39,7 @@
         <category name="formatting"/>
         <description>${project.description}</description>
         <parameters>
-            <parameter name="sourceUrl" type="enum" required="true">
+            <parameter name="sourceName" type="enum" required="true">
                 <option key="showNameInPlaceholder" value="false"/>
                 <option key="showValueInPlaceholder" value="false"/>
             </parameter>

--- a/MarkdownRendererPlugin/src/main/resources/js/dynamic-fields-logic.js
+++ b/MarkdownRendererPlugin/src/main/resources/js/dynamic-fields-logic.js
@@ -5,7 +5,7 @@
     const gitSourceType = "GIT";
     const svnSourceType = "SUBVERSION";
     const plainUrlSourceType = "PLAIN_URL";
-    const selectNodes = ["sourceUrl"];
+    const selectNodes = ["sourceName"];
     const inputNodes = ["svnCountry", "projectKey", "mainRepository", "pathToMarkdownFile", "branch", "plainUrl", "svnBranchPath"];
     const i18nKeyDescNameTempl = "MarkdownRendererPlugin.mdrenderer-macro.param.{0}.{1}.desc";
     const i18nKeyLabelNameTempl = "MarkdownRendererPlugin.mdrenderer-macro.param.{0}.{1}.label";
@@ -27,14 +27,14 @@
     
     MarkdownRendererMacro.prototype.fields = {
         "enum": {
-            "sourceUrl": function (param, options) {
+            "sourceName": function (param, options) {
                 let paramDiv = AJS.$(Confluence.Templates.MacroBrowser.macroParameterSelect());
                 let sourceDropDown = AJS.$("select", paramDiv);
                 let prevSourceType = "";
                 getSourcesList(sourceDropDown)
                 
                 sourceDropDown.change(function () {
-                    const selectedSource = $("select#macro-param-sourceUrl option:selected").text();
+                    const selectedSource = $("select#macro-param-sourceName option:selected").text();
                     sourceType = jsSourcesMap.get(selectedSource)
                     if (prevSourceType !== sourceType) {
                         prevSourceType = sourceType;
@@ -67,7 +67,7 @@
     };
     
     MarkdownRendererMacro.prototype.beforeParamsSet = function (selectedParams, macroSelected) {
-        selectedSource = selectedParams.sourceUrl;
+        selectedSource = selectedParams.sourceName;
         
         return selectedParams;
     };
@@ -113,7 +113,7 @@
                     sourceDropDown.prepend($("<option selected disabled hidden></option>").val('').html("-- Select Source --")); // Empty val to prevent saving in macro config screen
                     selectedSource = '';
                 } 
-                $("select#macro-param-sourceUrl").val(selectedSource).change();
+                $("select#macro-param-sourceName").val(selectedSource).change();
             }
         });
     }


### PR DESCRIPTION
Moved logic to check non-nullness of parameters only in relevant Source Type + updated flexmark library version + leading ">" are now properly removed in quoted code.

Please note there will be an impact on existing pages using the plugin as one of the external variable has been renamed (sourceUrl --> sourceName). On pages with broken plugin, user will need to reset "Source Name" field to the desired value after installation of the new plugin version.